### PR TITLE
Change Temperature and TopP to type float32

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -23,8 +23,8 @@ type ChatCompletionsRequest struct {
 	Stop             []string        `json:"stop,omitempty"`
 	Stream           bool            `json:"stream,omitempty"`
 	StreamOptions    *StreamOptions  `json:"stream_options,omitempty"`
-	Temperature      int             `json:"temperature,omitempty"`
-	TopP             *float32        `json:"top_p,omitempty"`
+	Temperature      float32         `json:"temperature,omitempty"`
+	TopP             float32         `json:"top_p,omitempty"`
 	Tools            *[]Tool         `json:"tools,omitempty"`
 	ToolChoice       any             `json:"tool_choice,omitempty"`
 	Logprobs         bool            `json:"logprobs,omitempty"`

--- a/request/request_test/validator_test.go
+++ b/request/request_test/validator_test.go
@@ -29,10 +29,42 @@ func TestValidateChatCompletionsRequest(t *testing.T) {
 		StreamOptions: &request.StreamOptions{
 			IncludeUsage: true,
 		},
-		Temperature: 2,
-		// TopP: nil,	// TODO: VN -- pass non nil
+		Temperature: 2.0,
+		TopP:        nil, // TODO: VN -- pass non nil
 	}
 	err := request.ValidateChatCompletionsRequest(req)
 	assert.NoError(t, err)
 	fmt.Println(err)
+}
+
+func TestValidateChatCompletionsRequestWithTopP(t *testing.T) {
+	req := &request.ChatCompletionsRequest{
+		Messages: []*request.Message{
+			{
+				Role:    request.RoleUser,
+				Content: "Hello",
+			},
+		},
+		Model:            deepseek.DEEPSEEK_CHAT_MODEL,
+		FrequencyPenalty: 1,
+		MaxTokens:        1,
+		PresencePenalty:  1,
+		ResponseFormat: &request.ResponseFormat{
+			Type: request.ResponseFormatText,
+		},
+		Stop:   []string{"MOD1"},
+		Stream: true,
+		StreamOptions: &request.StreamOptions{
+			IncludeUsage: true,
+		},
+		Temperature: 2.0,
+		TopP:        float32Ptr(0.5),
+	}
+	err := request.ValidateChatCompletionsRequest(req)
+	assert.NoError(t, err)
+	fmt.Println(err)
+}
+
+func float32Ptr(f float32) *float32 {
+	return &f
 }

--- a/request/validator.go
+++ b/request/validator.go
@@ -110,13 +110,13 @@ func validateMultipleFields(req *ChatCompletionsRequest) error {
 		return fmt.Errorf("err: presence_penalty is invalid; it should be number between -2 and 2")
 	}
 
-	if !(req.Temperature >= 0 && req.Temperature <= 2) {
-		return fmt.Errorf("err: temperature is invalid; it should be number between 0 and 2")
+	if !(req.Temperature >= 0.0 && req.Temperature <= 2.0) {
+		return fmt.Errorf("err: temperature is invalid; it should be number between 0.0 and 2.0")
 	}
 
 	if req.TopP != nil {
-		if !(*req.TopP > 0 && *req.TopP <= 1) {
-			return fmt.Errorf("err: invalid top_p value; the valid range of top_p is (0, 1.0]")
+		if !(*req.TopP > 0.0 && *req.TopP <= 1.0) {
+			return fmt.Errorf("err: invalid top_p value; the valid range of top_p is (0.0, 1.0]")
 		}
 	}
 


### PR DESCRIPTION
Fixes #1

Change the type of `Temperature` and `TopP` to `float32` in `request/request.go`.

* **request/request.go**
  - Change the type of `Temperature` from `int` to `float32`.
  - Change the type of `TopP` from `*float32` to `float32`.

* **request/validator.go**
  - Update the `validateMultipleFields` function to check that `Temperature` is between 0.0 and 2.0.
  - Update the `validateMultipleFields` function to check that `TopP` is between 0.0 and 1.0.

* **request/request_test/validator_test.go**
  - Update the test cases to test `Temperature` as a `float32`.
  - Add test cases to test `TopP` as `float32`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yichozy/deepseek/pull/2?shareId=60f4ec28-fdfb-4cb5-9a39-2f7ca29bd78d).