### PR TITLE
Fix build error in request validator

### DIFF
--- a/request/request_test/validator_test.go
+++ b/request/request_test/validator_test.go
@@ -30,7 +30,7 @@ func TestValidateChatCompletionsRequest(t *testing.T) {
 			IncludeUsage: true,
 		},
 		Temperature: 2.0,
-		TopP:        nil, // TODO: VN -- pass non nil
+		TopP:        float32Ptr(0.5), // Pfa8a
 	}
 	err := request.ValidateChatCompletionsRequest(req)
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes #3

Update `TestValidateChatCompletionsRequest` test in `request/request_test/validator_test.go` to pass a non-nil value for `TopP`.

* Change `TopP` from `nil` to `float32Ptr(0.5)` in the test case.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yichozy/deepseek/pull/4?shareId=0e21b87a-a6d8-4fa4-991b-82f3e10587db).