### PR TITLE
Fix invalid operation error in request/validator.go

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -23,8 +23,8 @@ type ChatCompletionsRequest struct {
 	Stop             []string        `json:"stop,omitempty"`
 	Stream           bool            `json:"stream,omitempty"`
 	StreamOptions    *StreamOptions  `json:"stream_options,omitempty"`
-	Temperature      float32         `json:"temperature,omitempty"`
-	TopP             float32         `json:"top_p,omitempty"`
+	Temperature      *float32        `json:"temperature,omitempty"`
+	TopP             *float32        `json:"top_p,omitempty"`
 	Tools            *[]Tool         `json:"tools,omitempty"`
 	ToolChoice       any             `json:"tool_choice,omitempty"`
 	Logprobs         bool            `json:"logprobs,omitempty"`

--- a/request/request_test/validator_test.go
+++ b/request/request_test/validator_test.go
@@ -29,8 +29,8 @@ func TestValidateChatCompletionsRequest(t *testing.T) {
 		StreamOptions: &request.StreamOptions{
 			IncludeUsage: true,
 		},
-		Temperature: 2.0,
-		TopP:        float32Ptr(0.5), // Pfa8a
+		Temperature: float32Ptr(2.0),
+		TopP:        float32Ptr(0.5),
 	}
 	err := request.ValidateChatCompletionsRequest(req)
 	assert.NoError(t, err)
@@ -57,7 +57,7 @@ func TestValidateChatCompletionsRequestWithTopP(t *testing.T) {
 		StreamOptions: &request.StreamOptions{
 			IncludeUsage: true,
 		},
-		Temperature: 2.0,
+		Temperature: float32Ptr(2.0),
 		TopP:        float32Ptr(0.5),
 	}
 	err := request.ValidateChatCompletionsRequest(req)

--- a/request/validator.go
+++ b/request/validator.go
@@ -110,8 +110,10 @@ func validateMultipleFields(req *ChatCompletionsRequest) error {
 		return fmt.Errorf("err: presence_penalty is invalid; it should be number between -2 and 2")
 	}
 
-	if !(req.Temperature >= 0.0 && req.Temperature <= 2.0) {
-		return fmt.Errorf("err: temperature is invalid; it should be number between 0.0 and 2.0")
+	if req.Temperature != nil {
+		if !(*req.Temperature >= 0.0 && *req.Temperature <= 2.0) {
+			return fmt.Errorf("err: temperature is invalid; it should be number between 0.0 and 2.0")
+		}
 	}
 
 	if req.TopP != nil {


### PR DESCRIPTION
Related to #5

Update `ChatCompletionsRequest` struct and validation logic to handle `TopP` and `Temperature` as pointers to `float32`.

* **request/request.go**
  - Change the type of `TopP` and `Temperature` fields in `ChatCompletionsRequest` struct to `*float32`.

* **request/validator.go**
  - Update the validation logic in `validateMultipleFields` function to handle `TopP` and `Temperature` as pointers.

* **request/request_test/validator_test.go**
  - Update the test cases to use `*float32` for `TopP` and `Temperature`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yichozy/deepseek/pull/6?shareId=3548026f-3264-495d-af8c-57ed082ad798).